### PR TITLE
Add user association to recipes

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -25,21 +25,31 @@ tasks:
     cmds:
       - docker compose up -d db
       - sleep 3 # wait for the database to start
-      - task: migrate
+      - task: db:migrate
       - docker compose up --build -d coffeehouse nats redis
       - sleep 1
       - docker logs --follow coffeehouse-coffeehouse-1
 
-  migrate:
+  db:migrate:
     desc: Run the database migrations with docker
     cmds:
       - docker run -v $(pwd)/sql/schema:/migrations --network host migrate/migrate -path=/migrations/ -database postgres://user:password@localhost:5432/coffeehousedb?sslmode=disable up
+  
+  db:rollback:
+    desc: Rollback the database migrations
+    cmds:
+      - docker run -v $(pwd)/sql/schema:/migrations --network host migrate/migrate -path=/migrations/ -database postgres://user:password@localhost:5432/coffeehousedb?sslmode=disable down 1
 
-  new_migration:
+  db:force:
+    desc: Force the database version to N
+    cmds:
+      - docker run -v $(pwd)/sql/schema:/migrations --network host migrate/migrate -path=/migrations/ -database postgres://user:password@localhost:5432/coffeehousedb?sslmode=disable force {{.CLI_ARGS}}
+
+  db:new_migration:
     desc: Create a new migration
     cmds:
       - migrate create -ext sql -dir sql/schema -seq {{.CLI_ARGS}}
-
+    
   pgcli:
     desc: Connect to the PostgreSQL database
     env:

--- a/endpoints.http
+++ b/endpoints.http
@@ -10,7 +10,8 @@ content-type: application/json
     "weight_unit": "g",
     "grind_size": 21,
     "water_weight": 500.0,
-    "water_unit": "g"
+    "water_unit": "g",
+    "user_id": 5
 }
 
 ### Get single recipe

--- a/postgres/models.go
+++ b/postgres/models.go
@@ -151,6 +151,7 @@ type Recipe struct {
 	WaterUnit     string          `json:"water_unit"`
 	WaterTemp     sql.NullFloat64 `json:"water_temp"`
 	WaterTempUnit sql.NullString  `json:"water_temp_unit"`
+	UserID        int32           `json:"user_id"`
 }
 
 type SavedRecipe struct {

--- a/routes.go
+++ b/routes.go
@@ -39,6 +39,7 @@ func (s *server) handleCreateRecipe() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		recip, err := decode[postgres.CreateRecipeParams](r)
 		if err != nil {
+			s.log.Error(err)
 			http.Error(w, "error decoding recipe", http.StatusBadRequest)
 			return
 		}
@@ -46,6 +47,7 @@ func (s *server) handleCreateRecipe() http.HandlerFunc {
 		log := s.log.With(
 			"method", recip.BrewMethod,
 			"recipe_name", recip.RecipeName,
+			"user_id", recip.UserID,
 		)
 
 		log.Info("adding recipe")

--- a/sql/query/query.sql
+++ b/sql/query/query.sql
@@ -8,9 +8,9 @@ ORDER BY brew_method;
 
 -- name: CreateRecipe :one
 INSERT INTO public.recipes (
-    recipe_name, brew_method, coffee_weight, weight_unit, grind_size, water_weight, water_unit, water_temp, water_temp_unit
+    recipe_name, brew_method, coffee_weight, weight_unit, grind_size, water_weight, water_unit, water_temp, water_temp_unit, user_id
 ) VALUES (
-  $1, $2, $3, $4, $5, $6, $7, $8, $9
+  $1, $2, $3, $4, $5, $6, $7, $8, $9, $10
 )
 RETURNING *;
 

--- a/sql/schema/000004_user_recipe_assoc.down.sql
+++ b/sql/schema/000004_user_recipe_assoc.down.sql
@@ -1,0 +1,4 @@
+-- drop the user_id column from the recipes table
+
+ALTER TABLE public.recipes
+DROP COLUMN user_id;

--- a/sql/schema/000004_user_recipe_assoc.up.sql
+++ b/sql/schema/000004_user_recipe_assoc.up.sql
@@ -1,0 +1,7 @@
+-- add a new column to the recipes table to store which user created the recipe. This will allow us to query for all recipes created by a specific user. We'll also add a foreign key constraint to ensure that the user_id references an existing user in the users table.
+
+ALTER TABLE public.recipes
+ADD COLUMN user_id integer NOT NULL DEFAULT 1,
+ADD CONSTRAINT fk_user_id
+FOREIGN KEY (user_id)
+REFERENCES public.users (id);

--- a/testdata/create_recipe.json
+++ b/testdata/create_recipe.json
@@ -1,0 +1,10 @@
+{
+    "recipe_name": "sample",
+    "brew_method": "chemex",
+    "coffee_weight": 20.0,
+    "weight_unit": "g",
+    "grind_size": 21,
+    "water_weight": 500.0,
+    "water_unit": "g",
+    "user_id": 1
+}


### PR DESCRIPTION
The motivation for this change is to enable tracking of which user created each recipe, allowing for user-specific queries and better data management. Previously, the system did not associate recipes with users, limiting the ability to filter or manage recipes based on user data.

This change introduces a new `user_id` field in the `recipes` table, along with a foreign key constraint to ensure it references an existing user in the `users` table. The `Taskfile.yaml` has been updated to include new database tasks for migration and rollback. The `endpoints.http`, `postgres/models.go`, `postgres/query.sql.go`, `routes.go`, and `routes_test.go` files have been updated to handle the new `user_id` field. Additionally, new SQL migration files and test data have been added to support these changes.
