### PR TITLE
Add OpenTelemetry and Jaeger support

### DIFF
--- a/k8s/coffeehouse-deployment.yaml
+++ b/k8s/coffeehouse-deployment.yaml
@@ -52,6 +52,11 @@ spec:
                 configMapKeyRef:
                   key: COFFEEHOUSE_REDIS_URL
                   name: docker-env
+            - name: COFFEEHOUSE_OTEL_COLLECTOR
+              valueFrom:
+                configMapKeyRef:
+                  key: COFFEEHOUSE_OTEL_COLLECTOR
+                  name: docker-env
           image: ghcr.io/rshep3087/coffeehouse:latest
           livenessProbe:
             httpGet:

--- a/k8s/docker-env-configmap.yaml
+++ b/k8s/docker-env-configmap.yaml
@@ -5,6 +5,7 @@ data:
   COFFEEHOUSE_DB_TLS: "true"
   COFFEEHOUSE_LISTEN_ADDR: 0.0.0.0:8080
   COFFEEHOUSE_NATS_URL: nats://nats:4222
+  COFFEEHOUSE_OTEL_COLLECTOR: otel-collector:4317
   COFFEEHOUSE_REDIS_URL: redis:6379
 kind: ConfigMap
 metadata:

--- a/k8s/jaeger-deployment.yaml
+++ b/k8s/jaeger-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -o k8s
+    kompose.version: 1.34.0 (HEAD)
+  labels:
+    io.kompose.service: jaeger
+  name: jaeger
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: jaeger
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -o k8s
+        kompose.version: 1.34.0 (HEAD)
+      labels:
+        io.kompose.service: jaeger
+    spec:
+      containers:
+        - image: jaegertracing/all-in-one:1.60
+          name: jaeger
+          ports:
+            - containerPort: 16686
+              protocol: TCP
+          resources:
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
+      restartPolicy: Always

--- a/k8s/jaeger-service.yaml
+++ b/k8s/jaeger-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -o k8s
+    kompose.version: 1.34.0 (HEAD)
+  labels:
+    io.kompose.service: jaeger
+  name: jaeger
+spec:
+  ports:
+    - name: "16686"
+      port: 16686
+      targetPort: 16686
+  selector:
+    io.kompose.service: jaeger

--- a/k8s/otel-collector-cm0-configmap.yaml
+++ b/k8s/otel-collector-cm0-configmap.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+data:
+  otel-collector.yaml: |-
+    # Copyright The OpenTelemetry Authors
+    # SPDX-License-Identifier: Apache-2.0
+
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+    processors:
+    extensions:
+      health_check: {}
+    exporters:
+      otlp:
+        endpoint: jaeger:4317
+        tls:
+          insecure: true
+      prometheus:
+        endpoint: 0.0.0.0:9090
+        namespace: testapp
+      debug:
+
+    service:
+      extensions: [health_check]
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: []
+          exporters: [otlp, debug]
+
+        metrics:
+          receivers: [otlp]
+          processors: []
+          exporters: [prometheus, debug]
+kind: ConfigMap
+metadata:
+  annotations:
+    use-subpath: "true"
+  labels:
+    io.kompose.service: otel-collector
+  name: otel-collector-cm0

--- a/k8s/otel-collector-deployment.yaml
+++ b/k8s/otel-collector-deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -o k8s
+    kompose.version: 1.34.0 (HEAD)
+  labels:
+    io.kompose.service: otel-collector
+  name: otel-collector
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: otel-collector
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -o k8s
+        kompose.version: 1.34.0 (HEAD)
+      labels:
+        io.kompose.service: otel-collector
+    spec:
+      containers:
+        - args:
+            - --config=/etc/otel-collector.yaml
+          image: otel/opentelemetry-collector-contrib:0.111.0
+          name: otel-collector
+          ports:
+            - containerPort: 4317
+              protocol: TCP
+          resources:
+            limits:
+              cpu: "500m"
+              memory: "256Mi"
+            requests:
+              cpu: "250m"
+              memory: "128Mi"
+          volumeMounts:
+            - mountPath: /etc/otel-collector.yaml
+              name: otel-collector-cm0
+              subPath: otel-collector.yaml
+      restartPolicy: Always
+      volumes:
+        - configMap:
+            items:
+              - key: otel-collector.yaml
+                path: otel-collector.yaml
+            name: otel-collector-cm0
+          name: otel-collector-cm0

--- a/k8s/otel-collector-service.yaml
+++ b/k8s/otel-collector-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -o k8s
+    kompose.version: 1.34.0 (HEAD)
+  labels:
+    io.kompose.service: otel-collector
+  name: otel-collector
+spec:
+  ports:
+    - name: "4317"
+      port: 4317
+      targetPort: 4317
+  selector:
+    io.kompose.service: otel-collector


### PR DESCRIPTION
Motivation for the change:
The motivation for this change is to integrate OpenTelemetry and Jaeger into the application for better observability and tracing capabilities. This will help in monitoring and debugging the application more effectively.

How it differs from the previous implementation:
- Add a new environment variable `COFFEEHOUSE_OTEL_COLLECTOR` in the `coffeehouse-deployment.yaml` to connect with the OpenTelemetry collector.
- Update the `docker-env-configmap.yaml` to include the `COFFEEHOUSE_OTEL_COLLECTOR` key with the value `otel-collector:4317`.
- Introduce a new deployment and service for Jaeger (`jaeger-deployment.yaml` and `jaeger-service.yaml`) to handle tracing.
- Add a new ConfigMap, deployment, and service for the OpenTelemetry collector (`otel-collector-cm0-configmap.yaml`, `otel-collector-deployment.yaml`, and `otel-collector-service.yaml`) to process and export telemetry data.
